### PR TITLE
Fix dynamic colormap sampling for labeled bubble chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Human-maintained config file. Important rows:
   - `figures/`
     - `Volume_Price_<bucket>_<window>.png` – pressure vs. price charts.
     - `Address_Bubbles_addresses_<window>.png` – bubble chart (by transaction count bins).
-    - `Address_Bubbles_by_label_<window>.png` – bubble chart (by label).
+    - `Address_Bubbles_by_label_<window>.png` – bubble chart (by label) with dynamic colors sourced from `settings.csv` address groups.
   - `analysis/`
     - `spike_buckets_<bucket>_<window>.csv`
     - `spike_addresses_<bucket>_<window>.csv`


### PR DESCRIPTION
## Summary
- ensure the label bubble chart uses matplotlib's `get_cmap` helper so dynamic palettes no longer raise at runtime
- guard color extraction so the ordered label list always maps to usable hex colors

## Testing
- `python scripts/run_tdccp_bubble_pipeline.py` *(fails: ModuleNotFoundError: No module named 'pandas' in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db3e76ab0c8333a1221472276205dc