### PR TITLE
Limit spike analysis to sell-heavy buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Human-maintained config file. Important rows:
 
 - `outputs/`
   - `figures/`
-    - `Volume_Price_<bucket>_<window>.png` – pressure vs. price charts.
+    - `VolumeLines_Price_<bucket>_<window>.png` – pressure vs. price charts.
+    - `VolumeLines_Price_<bucket>_<window>_spikes.png` – pressure vs. price with red-outlined spike buckets.
     - `Address_Bubbles_addresses_<window>.png` – bubble chart (by transaction count bins).
     - `Address_Bubbles_byLabel_<window>.png` – bubble chart (by label) with dynamic colors sourced from `settings.csv` address groups, plus `Address_Bubbles_byLabel_<window>_highlight_<group>.png` variants for each label active in the selected window.
   - `analysis/`
@@ -79,4 +80,22 @@ Human-maintained config file. Important rows:
 Run:
 ```bash
 python scripts/run_tdccp_pipeline.py
+```
 
+### 2. Address transaction bubble chart
+Render a per-transaction bubble chart (with TDCCP price overlay) for a specific wallet:
+
+```bash
+python scripts/plot_tdccp_address_transactions_bubble.py --owner <FROM_ADDRESS>
+```
+
+The script automatically respects the `START`/`END` window from `settings.csv`, fetches the owner's TDCCP balance-change history from Solscan, classifies each transaction (buy, sell, transfer, or airdrop), writes a CSV summary to `data/addresses/`, and saves the bubble chart to `outputs/figures/`. The overlayed TDCCP price line is resampled to an hourly series for consistency with the balance-change cadence.
+
+### 3. Spike-highlight pressure vs. price plots
+Run the direct-flow spike scanner to emit analysis CSVs and spike-highlight pressure/price plots:
+
+```bash
+python scripts/analyze_spikes.py --start <YYYY-MM-DD> --end <YYYY-MM-DD>
+```
+
+For every requested bucket the script now invokes `plot_tdccp_pressure_vs_price_spikes.py`, which reuses the swaps window to draw the standard volume-vs-price lines and outlines sell-heavy spike buckets (where `delta_direct_pct` is at or below `-min_delta_pct`) with red vertical rectangles. Resulting figures are written alongside the base pressure/price plots in `outputs/figures/`.

--- a/scripts/plot_tdccp_address_transactions_bubble.py
+++ b/scripts/plot_tdccp_address_transactions_bubble.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Plot a per-transaction TDCCP bubble chart for a single address."""
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.lines import Line2D
+from matplotlib.ticker import FuncFormatter
+
+# Re-use the Solscan helpers from fetch_address_history
+from fetch_address_history import (  # type: ignore
+    defaults_from_settings as history_window_defaults,
+    fetch_balance_changes,
+    fetch_token_accounts,
+    require_api_key,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS_CSV = ROOT / "settings.csv"
+DATA_DIR = ROOT / "data"
+SWAPS_CSV = DATA_DIR / "swaps.csv"
+PRICE_HISTORY_CSV = DATA_DIR / "tdccp_price_history.csv"
+OUT_FIG_DIR = ROOT / "outputs" / "figures"
+OUT_TX_DIR = DATA_DIR / "addresses"
+
+TDCCP_MINT_FALLBACK = "Hg8bKz4mvs8KNj9zew1cEF9tDw1x2GViB4RFZjVEmfrD"
+TDCCP_SYMBOL = "TDCCP"
+_MINT_CACHE: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Settings helpers
+# ---------------------------------------------------------------------------
+
+def read_settings_value(key_name: str) -> Optional[str]:
+    if not SETTINGS_CSV.exists():
+        return None
+    target = (key_name or "").strip().upper()
+    key_idx, val_idx = 1, 2
+    with SETTINGS_CSV.open("r", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        header = next(reader, None)
+        if header:
+            for i, col in enumerate(header):
+                lc = (col or "").strip().lower()
+                if lc == "key":
+                    key_idx = i
+                elif lc == "value":
+                    val_idx = i
+        for row in reader:
+            if not row or len(row) <= max(key_idx, val_idx):
+                continue
+            if (row[key_idx] or "").strip().upper() == target:
+                return (row[val_idx] or "").strip()
+    return None
+
+
+def window_defaults() -> Tuple[Optional[str], Optional[str]]:
+    start, end = history_window_defaults()
+    return start, end
+
+
+def mint_default() -> str:
+    global _MINT_CACHE
+    if _MINT_CACHE is not None:
+        return _MINT_CACHE
+    mint = read_settings_value("MINT")
+    _MINT_CACHE = mint or TDCCP_MINT_FALLBACK
+    return _MINT_CACHE
+
+
+# ---------------------------------------------------------------------------
+# Price helpers
+# ---------------------------------------------------------------------------
+
+
+def load_price_history(path: Path, *, verbose: bool = False) -> Optional[pd.DataFrame]:
+    if not path.exists():
+        if verbose:
+            print(f"[price] missing → {path}")
+        return None
+    df = pd.read_csv(path)
+    if "ts" not in df.columns:
+        if verbose:
+            print(f"[price] 'ts' column missing → {path}")
+        return None
+    ts = pd.to_datetime(df["ts"], utc=True, errors="coerce")
+    price_col = None
+    for cand in ["price_usd", "close", "price"]:
+        if cand in df.columns:
+            price_col = cand
+            break
+    if price_col is None:
+        if verbose:
+            print(f"[price] price column missing in {path}")
+        return None
+    clean = (
+        pd.DataFrame({"ts": ts, "price_usd": pd.to_numeric(df[price_col], errors="coerce")})
+        .dropna(subset=["ts", "price_usd"])
+        .sort_values("ts")
+    )
+    if clean.empty and verbose:
+        print(f"[price] no valid rows in {path}")
+    return clean if not clean.empty else None
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SwapClassification:
+    label: str
+    router_token1: Optional[str] = None
+    router_token2: Optional[str] = None
+    intermediary_label: Optional[str] = None
+
+
+def is_tdccp_token(value: str | float | int | None) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, float) and math.isnan(value):
+        return False
+    v = str(value).strip()
+    if not v:
+        return False
+    return v.upper() in {TDCCP_SYMBOL, TDCCP_MINT_FALLBACK.upper(), mint_default().upper()}
+
+
+def load_swaps_for_owner(owner: str, swaps_path: Path, *, verbose: bool = False) -> pd.DataFrame:
+    if not swaps_path.exists():
+        if verbose:
+            print(f"[info] swaps.csv not found at {swaps_path}; treating all txns as transfers")
+        return pd.DataFrame()
+    df = pd.read_csv(swaps_path, low_memory=False)
+    if df.empty:
+        return df
+    if "from_address" not in df.columns:
+        if verbose:
+            print(f"[warn] swaps.csv missing 'from_address'; cannot match transactions")
+        return pd.DataFrame()
+    df["from_address"] = df["from_address"].astype(str)
+    owner_rows = df[df["from_address"] == owner].copy()
+    if owner_rows.empty and verbose:
+        print(f"[info] swaps.csv has no rows for owner {owner}")
+    return owner_rows
+
+
+def classify_from_swaps(tx_hash: str, swaps: pd.DataFrame) -> Optional[SwapClassification]:
+    if swaps.empty:
+        return None
+    if "trans_id" not in swaps.columns:
+        return None
+    matches = swaps[swaps["trans_id"].astype(str) == tx_hash]
+    if matches.empty:
+        return None
+    if "intermediary_label" in matches.columns:
+        direct = matches[matches["intermediary_label"].astype(str).str.lower() == "direct"]
+        if not direct.empty:
+            matches = direct
+    # Check token sides
+    rt1 = matches.get("router_token1")
+    rt2 = matches.get("router_token2")
+    lbl = matches.get("intermediary_label")
+    first_lbl = (lbl.iloc[0] if lbl is not None and not lbl.empty else None)
+    if rt1 is not None and rt1.astype(str).apply(is_tdccp_token).any():
+        token1 = rt1.iloc[0]
+        token2 = rt2.iloc[0] if rt2 is not None and not rt2.empty else None
+        return SwapClassification("buy", token1, token2, first_lbl)
+    if rt2 is not None and rt2.astype(str).apply(is_tdccp_token).any():
+        token1 = rt1.iloc[0] if rt1 is not None and not rt1.empty else None
+        token2 = rt2.iloc[0]
+        return SwapClassification("sell", token1, token2, first_lbl)
+    return SwapClassification("transfer", rt1.iloc[0] if rt1 is not None and not rt1.empty else None,
+                              rt2.iloc[0] if rt2 is not None and not rt2.empty else None,
+                              first_lbl)
+
+
+def detect_airdrop(amount: float, classification: Optional[SwapClassification], *, change_direction: str) -> bool:
+    if classification is not None and classification.label in {"buy", "sell"}:
+        return False
+    if change_direction.lower() != "inc":
+        return False
+    return math.isclose(amount, 777.0, rel_tol=1e-6, abs_tol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Plot helpers
+# ---------------------------------------------------------------------------
+
+
+def compute_bubble_sizes(amounts: pd.Series) -> np.ndarray:
+    base = amounts.abs().clip(lower=1e-4)
+    return np.sqrt(base) * 25.0
+
+
+def legend_handles(
+    color_map: Dict[str, str],
+    labels: Iterable[str],
+    display_map: Dict[str, str],
+) -> Iterable[Line2D]:
+    for label in labels:
+        color = color_map[label]
+        yield Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="white",
+            markerfacecolor=color,
+            markeredgecolor="black",
+            markeredgewidth=0.6,
+            markersize=12,
+            label=display_map.get(label, label.title()),
+        )
+
+
+def tint_legend_text(legend, color_map: Dict[str, str], display_map: Dict[str, str]) -> None:
+    if legend is None:
+        return
+    reverse_display = {display: key for key, display in display_map.items()}
+    for text in legend.get_texts():
+        key = text.get_text().strip().lower()
+        match_key = None
+        if key in color_map:
+            match_key = key
+        else:
+            lookup = reverse_display.get(text.get_text().strip())
+            if lookup:
+                match_key = lookup
+        if match_key and match_key in color_map:
+            text.set_color(color_map[match_key])
+
+
+def fmt_tdccp(v, _pos):
+    try:
+        if abs(v) >= 1_000_000:
+            return f"{v/1_000_000:.1f}M"
+        if abs(v) >= 1_000:
+            return f"{v/1_000:.1f}k"
+        if abs(v - int(v)) < 1e-9:
+            return f"{int(v)}"
+        return f"{v:.2f}"
+    except Exception:
+        return str(v)
+
+
+def resample_price_hourly(price: pd.DataFrame) -> pd.DataFrame:
+    if price.empty:
+        return price
+    hourly = (
+        price.set_index("ts")
+        .resample("1h")
+        .last()
+        .dropna(subset=["price_usd"])
+        .reset_index()
+        .sort_values("ts")
+    )
+    return hourly
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def parse_figsize(text: str) -> Tuple[float, float]:
+    try:
+        if "x" in text:
+            w, h = text.split("x", 1)
+        elif "," in text:
+            w, h = text.split(",", 1)
+        else:
+            raise ValueError
+        return float(w), float(h)
+    except Exception as exc:
+        raise SystemExit("[error] --figsize must be WIDTHxHEIGHT or WIDTH,HEIGHT (e.g. 20,10)") from exc
+
+
+def human_window_label(start: pd.Timestamp, end: pd.Timestamp) -> str:
+    return f"{start.strftime('%Y%m%d')}-{end.strftime('%Y%m%d')}"
+
+
+def gather_transactions(
+    owner: str,
+    mint: str,
+    start_iso: str,
+    end_iso: str,
+    api_key: str,
+    *,
+    verbose: bool = False,
+) -> pd.DataFrame:
+    accounts_df = fetch_token_accounts(owner, api_key, page_size=40)
+    if accounts_df.empty:
+        if verbose:
+            print(f"[warn] no token accounts returned for owner {owner}")
+        return pd.DataFrame()
+    mint_rows = accounts_df[accounts_df["token_address"].astype(str) == mint]
+    if mint_rows.empty:
+        if verbose:
+            print(f"[warn] owner {owner} has no token account for mint {mint}")
+        return pd.DataFrame()
+    all_hist: list[pd.DataFrame] = []
+    for _, row in mint_rows.iterrows():
+        token_account = str(row["token_account"])
+        if verbose:
+            print(f"[fetch] balance changes owner={owner} token_account={token_account}")
+        hist = fetch_balance_changes(owner, token_account, mint, start_iso, end_iso, api_key, page_size=40)
+        if hist.empty:
+            continue
+        hist["token_account"] = token_account
+        all_hist.append(hist)
+    if not all_hist:
+        return pd.DataFrame()
+    hist_df = pd.concat(all_hist, ignore_index=True)
+    hist_df["time_iso"] = pd.to_datetime(hist_df.get("time"), utc=True, errors="coerce")
+    hist_df["direction"] = hist_df.get("change_type", "").astype(str)
+    hist_df["direction"] = hist_df["direction"].str.lower().where(hist_df["direction"].notna(), "")
+    hist_df["amount_ui"] = pd.to_numeric(hist_df.get("amount_ui"), errors="coerce").fillna(0.0)
+    hist_df["signed_amount_ui"] = np.where(
+        hist_df["direction"] == "inc",
+        hist_df["amount_ui"],
+        -hist_df["amount_ui"],
+    )
+    hist_df = hist_df.dropna(subset=["trans_id", "time_iso"])
+    return hist_df
+
+
+def aggregate_transactions(hist_df: pd.DataFrame) -> pd.DataFrame:
+    if hist_df.empty:
+        return pd.DataFrame(columns=[
+            "trans_id",
+            "first_seen",
+            "block_time",
+            "net_amount_ui",
+            "abs_amount_ui",
+            "direction",
+            "token_accounts",
+        ])
+    grouped = hist_df.groupby("trans_id")
+    records: list[dict] = []
+    for tx_id, grp in grouped:
+        ts = grp["time_iso"].min()
+        block_time = pd.to_numeric(grp.get("block_time"), errors="coerce").min()
+        net = grp["signed_amount_ui"].sum()
+        direction = "inc" if net > 0 else "dec" if net < 0 else "flat"
+        token_accounts = sorted(set(grp.get("token_account", "").astype(str)))
+        records.append({
+            "trans_id": str(tx_id),
+            "first_seen": ts,
+            "block_time": block_time,
+            "net_amount_ui": net,
+            "abs_amount_ui": abs(net),
+            "direction": direction,
+            "token_accounts": ";".join(token_accounts),
+        })
+    out = pd.DataFrame(records)
+    out = out.sort_values("first_seen")
+    return out
+
+
+def build_plot_dataframe(
+    aggregated: pd.DataFrame,
+    swaps: pd.DataFrame,
+    *,
+    verbose: bool = False,
+) -> pd.DataFrame:
+    if aggregated.empty:
+        return aggregated
+    classifications: list[str] = []
+    router1: list[Optional[str]] = []
+    router2: list[Optional[str]] = []
+    intermed: list[Optional[str]] = []
+    for _, row in aggregated.iterrows():
+        tx_hash = str(row["trans_id"])
+        classification = classify_from_swaps(tx_hash, swaps)
+        label = None if classification is None else classification.label
+        if label is None:
+            label = "transfer"
+        if label == "transfer" and detect_airdrop(row["abs_amount_ui"], classification, change_direction=row["direction"]):
+            label = "airdrop"
+        classifications.append(label)
+        router1.append(None if classification is None else classification.router_token1)
+        router2.append(None if classification is None else classification.router_token2)
+        intermed.append(None if classification is None else classification.intermediary_label)
+    aggregated = aggregated.copy()
+    aggregated["classification"] = classifications
+    aggregated["router_token1"] = router1
+    aggregated["router_token2"] = router2
+    aggregated["intermediary_label"] = intermed
+    aggregated["signed_amount"] = aggregated["net_amount_ui"]
+    aggregated["timestamp"] = aggregated["first_seen"]
+    aggregated = aggregated.dropna(subset=["timestamp"])
+    aggregated["timestamp"] = pd.to_datetime(aggregated["timestamp"], utc=True)
+    aggregated = aggregated[aggregated["abs_amount_ui"] > 0]
+    if verbose and aggregated.empty:
+        print("[warn] after filtering zero-amount transactions nothing remains")
+    return aggregated
+
+
+def write_transactions_csv(df: pd.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+    print(f"[done] wrote transactions → {path} (rows={len(df)})")
+
+
+def plot_transactions(
+    df: pd.DataFrame,
+    price: Optional[pd.DataFrame],
+    outfile: Path,
+    *,
+    owner: str,
+    window_label: str,
+    figsize: Tuple[float, float],
+    dpi: int,
+) -> None:
+    if df.empty:
+        print("[warn] no transactions to plot; skipping figure")
+        return
+    colors = {
+        "buy": "#2ca02c",
+        "sell": "#d62728",
+        "transfer": "#1f77b4",
+        "airdrop": "#9467bd",
+    }
+    display_names = {
+        "buy": "Buy (green)",
+        "sell": "Sell (red)",
+        "transfer": "Normal transfer (blue)",
+        "airdrop": "Airdrop (purple)",
+    }
+    df["classification"] = df["classification"].astype(str).str.lower()
+    df["color"] = df["classification"].map(lambda v: colors.get(v, "#7f7f7f"))
+    sizes = compute_bubble_sizes(df["abs_amount_ui"])
+
+    legend_order = ["buy", "sell", "transfer", "airdrop"]
+    present_set = set(df["classification"])
+    present_labels = [label for label in legend_order if label in present_set]
+
+    fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
+    ax.set_facecolor("white")
+
+    ax.scatter(
+        df["timestamp"],
+        df["signed_amount"],
+        s=sizes,
+        c=df["color"],
+        alpha=0.7,
+        edgecolors="black",
+        linewidths=0.6,
+    )
+
+    ax.axhline(0, color="#606060", linewidth=1.0, alpha=0.8)
+    ax.set_ylabel("Signed TDCCP amount")
+    ax.yaxis.set_major_formatter(FuncFormatter(fmt_tdccp))
+    ax.grid(True, which="major", axis="both", linestyle="--", alpha=0.35)
+    ax.tick_params(axis="both", labelsize=12)
+
+    ax.set_xlabel("Transaction time (UTC)")
+    title = f"TDCCP Transactions • {owner} • {window_label}"
+    ax.set_title(title, fontsize=18, pad=14)
+
+    # Legend
+    if present_labels:
+        handles = list(legend_handles(colors, present_labels, display_names))
+        legend = ax.legend(
+            handles=handles,
+            title="Classification",
+            loc="upper left",
+            frameon=True,
+            framealpha=0.9,
+        )
+        tint_legend_text(legend, colors, display_names)
+
+    # Secondary axis for price
+    if price is not None and not price.empty:
+        price = resample_price_hourly(price)
+    if price is not None and not price.empty:
+        ax2 = ax.twinx()
+        ax2.plot(
+            price["ts"],
+            price["price_usd"],
+            color="black",
+            linewidth=1.2,
+            alpha=0.85,
+            label="TDCCP Price (USD, hourly)",
+        )
+        ax2.set_ylabel("TDCCP Price (USD, hourly)")
+        ax2.yaxis.set_major_formatter(FuncFormatter(fmt_tdccp))
+        ax2.grid(False)
+        # combine legends
+        lines1, labels1 = ax.get_legend_handles_labels()
+        lines2, labels2 = ax2.get_legend_handles_labels()
+        legend = ax.legend(
+            lines1 + lines2,
+            labels1 + labels2,
+            loc="upper left",
+            frameon=True,
+            framealpha=0.9,
+        )
+        tint_legend_text(legend, colors, display_names)
+    else:
+        tint_legend_text(ax.get_legend(), colors, display_names)
+
+    fig.autofmt_xdate()
+    outfile.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(outfile)
+    plt.close(fig)
+    print(f"[done] wrote figure → {outfile}")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Fetch TDCCP transactions for an address and plot a bubble chart with TDCCP price overlay.",
+    )
+    ap.add_argument("--owner", required=True, help="Owner (from_address) public key")
+    ap.add_argument("--start", help="Start date/time in ISO (default: settings START)")
+    ap.add_argument("--end", help="End date/time in ISO (default: settings END)")
+    ap.add_argument("--mint", help="TDCCP mint address (default: settings MINT)")
+    ap.add_argument("--swaps-csv", default=str(SWAPS_CSV), help="Path to swaps.csv (default: data/swaps.csv)")
+    ap.add_argument(
+        "--price-csv",
+        default=str(PRICE_HISTORY_CSV),
+        help="Path to TDCCP price history CSV (default: data/tdccp_price_history.csv)",
+    )
+    ap.add_argument("--out-csv", help="Optional explicit path for the output transactions CSV")
+    ap.add_argument("--out-fig", help="Optional explicit path for the output figure")
+    ap.add_argument("--figsize", default="20,10", help="Figure size as WIDTH,HEIGHT (default: 20,10)")
+    ap.add_argument("--dpi", type=int, default=220, help="Figure DPI (default: 220)")
+    ap.add_argument("--verbose", action="store_true", help="Verbose logging")
+    args = ap.parse_args()
+
+    owner = args.owner.strip()
+    if not owner:
+        raise SystemExit("[error] --owner must not be blank")
+
+    start_default, end_default = window_defaults()
+    start_str = args.start or start_default
+    end_str = args.end or end_default
+    if not start_str or not end_str:
+        raise SystemExit("[error] start/end not provided and not found in settings.csv")
+
+    mint = args.mint or mint_default()
+
+    start_ts = pd.to_datetime(start_str, utc=True, errors="raise")
+    end_ts = pd.to_datetime(end_str, utc=True, errors="raise")
+    window_label = human_window_label(start_ts, end_ts)
+
+    if args.verbose:
+        print(f"[info] owner={owner}")
+        print(f"[info] window={start_ts.isoformat()} → {end_ts.isoformat()}")
+        print(f"[info] mint={mint}")
+
+    api_key = require_api_key()
+
+    hist = gather_transactions(owner, mint, start_str, end_str, api_key, verbose=args.verbose)
+    if hist.empty:
+        print("[warn] no TDCCP balance changes found for this owner/window")
+        empty_df = pd.DataFrame(columns=[
+            "trans_id",
+            "timestamp",
+            "net_amount_ui",
+            "abs_amount_ui",
+            "direction",
+            "classification",
+            "router_token1",
+            "router_token2",
+            "intermediary_label",
+            "token_accounts",
+        ])
+        out_csv = Path(args.out_csv) if args.out_csv else OUT_TX_DIR / f"{owner}_{window_label}_tdccp_transactions.csv"
+        write_transactions_csv(empty_df, out_csv)
+        return
+
+    aggregated = aggregate_transactions(hist)
+    swaps = load_swaps_for_owner(owner, Path(args.swaps_csv), verbose=args.verbose)
+    plot_df = build_plot_dataframe(aggregated, swaps, verbose=args.verbose)
+
+    out_csv = Path(args.out_csv) if args.out_csv else OUT_TX_DIR / f"{owner}_{window_label}_tdccp_transactions.csv"
+    write_transactions_csv(plot_df, out_csv)
+
+    price = load_price_history(Path(args.price_csv), verbose=args.verbose)
+    if price is not None:
+        price = price[(price["ts"] >= start_ts) & (price["ts"] <= end_ts)]
+
+    out_fig = Path(args.out_fig) if args.out_fig else OUT_FIG_DIR / f"TDCCP_Transactions_{owner}_{window_label}.png"
+    figsize = parse_figsize(args.figsize)
+    plot_transactions(plot_df, price, out_fig, owner=owner, window_label=window_label, figsize=figsize, dpi=args.dpi)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/scripts/plot_tdccp_pressure_vs_price_spikes.py
+++ b/scripts/plot_tdccp_pressure_vs_price_spikes.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+import matplotlib.pyplot as plt
+from matplotlib.ticker import FuncFormatter
+import pandas as pd
+
+from plot_tdccp_pressure_vs_price import (
+    default_window_from_settings,
+    tdccp_mint_from_settings,
+    detect_time_column,
+    ensure_ts,
+    derive_tdccp_delta_ui,
+    human_ts_range_label,
+    format_ytick_plain,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+FIG_DIR = ROOT / "outputs" / "figures"
+
+
+def _load_price_history(price_path: Path, debug: bool = False) -> Optional[pd.DataFrame]:
+    if not price_path.exists():
+        if debug:
+            print(f"[price] missing: {price_path}")
+        return None
+    df = pd.read_csv(price_path)
+    if "ts" not in df.columns:
+        if debug:
+            print(f"[price] 'ts' column missing in {price_path}")
+        return None
+    df["ts"] = pd.to_datetime(df["ts"], utc=True, errors="coerce")
+    px_col = None
+    for cand in ("price_usd", "close", "price"):
+        if cand in df.columns:
+            px_col = cand
+            break
+    if not px_col:
+        if debug:
+            print(f"[price] no price column found in {price_path}")
+        return None
+    price = df.dropna(subset=["ts", px_col]).sort_values("ts").rename(columns={px_col: "price_usd"})
+    if debug:
+        print(f"[price] loaded {len(price)} rows from {price_path}")
+    return price[["ts", "price_usd"]]
+
+
+def _bucket_to_timedelta(bucket: str) -> pd.Timedelta:
+    try:
+        return pd.to_timedelta(bucket)
+    except ValueError as exc:
+        raise SystemExit(f"[error] unsupported bucket '{bucket}' — use pandas-compatible offsets") from exc
+
+
+def _load_flows(
+    swaps_path: Path,
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    symbol: str,
+    debug: bool = False,
+) -> pd.DataFrame:
+    if not swaps_path.exists():
+        sys.exit(f"[error] swaps csv not found: {swaps_path}")
+    df = pd.read_csv(swaps_path, low_memory=False)
+    if df.empty:
+        sys.exit(f"[error] swaps csv is empty: {swaps_path}")
+
+    tcol = detect_time_column(df)
+    df["ts"] = ensure_ts(df, tcol)
+    window = df[(df["ts"] >= start) & (df["ts"] < end)].copy()
+    if debug:
+        print(f"[swaps] {len(df)} total rows; window {start}→{end} → {len(window)} rows")
+
+    tdccp_mint = tdccp_mint_from_settings()
+    if not tdccp_mint:
+        sys.exit("[error] MINT not found in settings.csv (Key= MINT). Needed to identify TDCCP swaps.")
+
+    if "net_tdccp" in window.columns:
+        delta = pd.to_numeric(window["net_tdccp"], errors="coerce")
+        if debug:
+            usable = delta.notna().sum()
+            print(f"[flows] using 'net_tdccp' (usable rows: {usable}/{len(delta)})")
+    else:
+        if debug:
+            print("[flows] 'net_tdccp' missing—deriving TDCCP delta from token columns.")
+        delta = derive_tdccp_delta_ui(window, tdccp_mint, symbol, debug=debug)
+
+    if "intermediary_label" in window.columns:
+        inter = window["intermediary_label"].astype(str).str.lower()
+        is_intermed = inter.str.contains("intermed")
+    else:
+        is_intermed = pd.Series(False, index=window.index)
+
+    flows = window.assign(delta=delta, is_intermed=is_intermed)[["ts", "delta", "is_intermed"]]
+    flows = flows.dropna(subset=["delta"])
+    if debug:
+        print(f"[flows] sample:\n{flows.head(5)}")
+    return flows
+
+
+def _collect_spike_windows(
+    metrics_path: Path, min_delta_pct: float, debug: bool = False
+) -> list[pd.Timestamp]:
+    if not metrics_path.exists():
+        sys.exit(f"[error] metrics csv not found: {metrics_path}")
+    df = pd.read_csv(metrics_path)
+    if "bucket" not in df.columns or "delta_direct_pct" not in df.columns:
+        sys.exit(
+            "[error] metrics csv missing required columns 'bucket' and 'delta_direct_pct'"
+        )
+    df["bucket"] = pd.to_datetime(df["bucket"], utc=True, errors="coerce")
+    df = df.dropna(subset=["bucket"])
+    thresh = abs(min_delta_pct)
+    spikes = df.loc[df["delta_direct_pct"] <= -thresh, "bucket"].sort_values()
+    if debug:
+        print(
+            f"[spikes] {len(spikes)} sell-heavy buckets with delta_direct_pct ≤ -{thresh}"
+        )
+    return list(spikes)
+
+
+def _plot_bucket_with_spikes(
+    bucket: str,
+    flows: pd.DataFrame,
+    price: Optional[pd.DataFrame],
+    label: str,
+    outfile_dir: Path,
+    spike_starts: Iterable[pd.Timestamp],
+    debug: bool = False,
+) -> Path:
+    if flows.empty:
+        if debug:
+            print(f"[plot] {bucket}: no flows available → skipping")
+        return Path()
+
+    w = flows.set_index("ts")
+    buy = w.loc[w["delta"] > 0, "delta"].resample(bucket).sum().fillna(0.0)
+    sell = (-w.loc[w["delta"] < 0, "delta"]).resample(bucket).sum().fillna(0.0)
+    inter_buy = (
+        w.loc[(w["delta"] > 0) & (w["is_intermed"]), "delta"]
+        .resample(bucket).sum().fillna(0.0)
+    )
+
+    if buy.empty and sell.empty and inter_buy.empty:
+        if debug:
+            print(f"[plot] {bucket}: no resampled volumes → skipping")
+        return Path()
+
+    p = None
+    if price is not None and not price.empty:
+        p = price.set_index("ts").resample(bucket)["price_usd"].last().dropna()
+
+    fig, ax = plt.subplots(figsize=(20, 10), dpi=300)
+    ax.plot(buy.index, buy.values, linewidth=1.5, label="Buy volume (TDCCP)", color="green")
+    ax.plot(sell.index, sell.values, linewidth=1.5, label="Sell volume (TDCCP)", color="red")
+    ax.plot(
+        inter_buy.index,
+        inter_buy.values,
+        linewidth=1.5,
+        linestyle="--",
+        label="Intermediary buy volume",
+        color="blue",
+    )
+
+    ax.set_title(f"TDCCP Volume vs Price • Spikes Highlight • {bucket} • {label}")
+    ax.set_ylabel("Volume (TDCCP units)")
+    ax.yaxis.set_major_formatter(FuncFormatter(format_ytick_plain))
+    ax.grid(True, axis="both", linestyle="--", alpha=0.5)
+
+    ax2 = None
+    if p is not None and not p.empty:
+        ax2 = ax.twinx()
+        ax2.plot(p.index, p.values, linewidth=1.5, alpha=1, label="Price (USD)", color="black")
+        ax2.set_ylabel("Price (USD)")
+        ax2.yaxis.set_major_formatter(FuncFormatter(format_ytick_plain))
+        ax2.grid(False)
+
+    spike_starts = list(spike_starts)
+    if spike_starts:
+        width = _bucket_to_timedelta(bucket)
+        ax.relim()
+        ax.autoscale_view()
+        ymin, ymax = ax.get_ylim()
+        if ymin == ymax:
+            pad = abs(ymin) if ymin != 0 else 1.0
+            ymin -= pad
+            ymax += pad
+            ax.set_ylim(ymin, ymax)
+        for start in spike_starts:
+            if pd.isna(start):
+                continue
+            end = start + width
+            span = ax.axvspan(
+                start,
+                end,
+                ymin=0.0,
+                ymax=1.0,
+                facecolor="none",
+                edgecolor="red",
+                linewidth=2.0,
+            )
+            span.set_zorder(ax.lines[0].get_zorder() + 1 if ax.lines else 3)
+
+    if ax2 is not None:
+        lines, labels = [], []
+        for a in (ax, ax2):
+            lns, lbs = a.get_legend_handles_labels()
+            lines.extend(lns)
+            labels.extend(lbs)
+        ax.legend(lines, labels, loc="upper left")
+    else:
+        ax.legend(loc="upper left")
+
+    fig.autofmt_xdate()
+    outfile_dir.mkdir(parents=True, exist_ok=True)
+    out = outfile_dir / f"VolumeLines_Price_{bucket}_{label}_spikes.png"
+    fig.tight_layout()
+    fig.savefig(out)
+    plt.close(fig)
+    if debug:
+        print(f"[plot] wrote {out}")
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Plot TDCCP volume vs price per bucket with spike windows highlighted in red."
+        )
+    )
+    ap.add_argument("--bucket", required=True, help="Resample bucket size (e.g. 1d,12h,3h,1h,30min)")
+    ap.add_argument("--metrics", required=True, help="Path to spike metrics CSV for the bucket")
+    ap.add_argument(
+        "--min-delta-pct",
+        type=float,
+        required=True,
+        help=(
+            "Threshold applied to delta_direct_pct (only buckets with sell-side "
+            "imbalance ≤ -threshold are highlighted)"
+        ),
+    )
+    ap.add_argument("--start", help="UTC start YYYY-mm-dd (defaults to settings START)")
+    ap.add_argument("--end", help="UTC end YYYY-mm-dd (defaults to settings END)")
+    ap.add_argument("--symbol", default="TDCCP", help="Symbol fallback when mint columns show symbols")
+    ap.add_argument("--swaps", default=str(DATA / "swaps.csv"), help="Path to swaps.csv")
+    ap.add_argument(
+        "--price",
+        default=str(DATA / "tdccp_price_history.csv"),
+        help="Path to TDCCP price history CSV (optional)",
+    )
+    ap.add_argument(
+        "--outfile-dir",
+        default=str(FIG_DIR),
+        help=f"Output directory for figures (default: {FIG_DIR})",
+    )
+    ap.add_argument("--debug", action="store_true", help="Verbose logging")
+    args = ap.parse_args()
+
+    s_def, e_def = default_window_from_settings()
+    start_str = args.start or s_def
+    end_str = args.end or e_def
+    if not start_str or not end_str:
+        sys.exit("[error] --start/--end not provided and START/END missing in settings.csv")
+
+    start = pd.to_datetime(start_str, utc=True, errors="coerce")
+    end = pd.to_datetime(end_str, utc=True, errors="coerce")
+    if pd.isna(start) or pd.isna(end) or end <= start:
+        sys.exit("[error] invalid start/end; ensure ISO YYYY-MM-DD and end > start")
+
+    label = human_ts_range_label(start, end)
+    flows = _load_flows(Path(args.swaps), start, end, args.symbol, debug=args.debug)
+
+    price_df = _load_price_history(Path(args.price), debug=args.debug)
+    if price_df is not None:
+        price_df = price_df[(price_df["ts"] >= start) & (price_df["ts"] < end)]
+
+    spikes = _collect_spike_windows(Path(args.metrics), args.min_delta_pct, debug=args.debug)
+
+    out = _plot_bucket_with_spikes(
+        args.bucket,
+        flows,
+        price_df,
+        label,
+        Path(args.outfile_dir),
+        spikes,
+        debug=args.debug,
+    )
+    if not out or not out.exists():
+        sys.exit(
+            "[error] spike-highlight figure was not produced.\n"
+            "Possible causes: no flows detected, unsupported bucket, or empty metrics."
+        )
+
+    print(f"[done] wrote spike-highlight figure: {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- restrict `analyze_spikes.py` to flag spike buckets only when the direct-flow imbalance is sell-heavy beyond the threshold
- update the spike highlight plotter to honor the sell-side filter and document the behavior in the README

## Testing
- python -m compileall scripts/analyze_spikes.py scripts/plot_tdccp_pressure_vs_price_spikes.py


------
https://chatgpt.com/codex/tasks/task_e_68db91e639548333a874089c6443f3c6