### PR TITLE
Normalize address keys when loading Solscan peaks

### DIFF
--- a/docs/negative_peak_balances.md
+++ b/docs/negative_peak_balances.md
@@ -1,0 +1,49 @@
+# TDCCP peak balances and their data sources
+
+Early versions of the bubble metrics inferred the per-address `peak_balance_ui`
+by integrating **only** the swap ledger (`data/swaps.csv`). If a wallet received
+TDCCP via a plain transfer or airdrop and subsequently routed every token out
+through swaps, the running sum of `net_tdccp` inside the window never moved above
+zero. The CSV therefore reported a "peak" that was either zero or, worse,
+negative—an artefact of ignoring the non-swap inflows.
+
+The metrics builder (`scripts/build_bubble_pipeline.py`) now looks for the
+per-address balance histories emitted by `scripts/fetch_address_history.py`
+(`data/addresses/<owner>_<start>-<end>.csv`). When those files are present the
+script computes each wallet's peak TDCCP exposure from the Solscan balance
+change stream instead of the swap ledger. The resulting `peak_balance_ui` is the
+maximum `pre_ui`/`post_ui` observed during the analysis window, so it always
+reflects the true highest balance the owner held—even if every swap in the
+window was an outflow.
+
+Each metrics row now carries a helper column, `peak_balance_source`, which is
+`history` when Solscan data was available and `missing_history` when the
+analysis had to fall back to `0.0` because no balance history file existed for
+that address/window. There is **no** swap-derived fallback anymore; fetch the
+history, rerun the pipeline, and the peak will automatically be sourced from the
+on-chain balance changes. The fetcher writes two artefacts per address/window:
+
+* `<owner>_<start>-<end>.csv` — raw Solscan balance-change rows (with
+  `pre_ui`/`post_ui`).
+* `<owner>_<start>-<end>_transactions.csv` — one row per TDCCP transaction with
+  the signed `net_amount_ui`, the reconstructed running balance, and a
+  cumulative peak column you can compare directly to the bubble chart's running
+  sums.
+
+Run it like this:
+
+```bash
+python scripts/fetch_address_history.py \
+  --owner <FROM_ADDRESS> \
+  --token-mint <TDCCP_MINT> \
+  --start 2025-03-01 --end 2025-09-23
+python scripts/build_bubble_pipeline.py --debug
+```
+
+Replace `<TDCCP_MINT>` with the mint listed under `core,MINT` in `settings.csv`.
+
+To manually verify a peak that was sourced from history, open the corresponding
+CSV and check the highest `pre_ui`/`post_ui` value within the window—the metrics
+CSV will match that number. If the `peak_balance_source` says `missing_history`,
+the address simply lacks a fetched balance history; fetching it will upgrade the
+metrics on the next run.

--- a/scripts/build_bubble_pipeline.py
+++ b/scripts/build_bubble_pipeline.py
@@ -5,15 +5,15 @@ import argparse
 import csv
 import sys
 from pathlib import Path
-from typing import Optional, Tuple, List
+from typing import Dict, Optional, Tuple, List, Iterable
 
 import pandas as pd
-import numpy as np
 
 ROOT = Path(__file__).resolve().parents[1]
 DATA = ROOT / "data"
 SWAPS = DATA / "swaps.csv"
 OUT_DEFAULT = ROOT / "data" / "addresses" / "tdccp_address_metrics.csv"
+BALANCE_HISTORY_DIR = OUT_DEFAULT.parent
 SETTINGS = ROOT / "settings.csv"
 
 
@@ -78,7 +78,201 @@ def ensure_ts(df: pd.DataFrame, time_col: str) -> pd.Series:
 
 # --------------------------- metrics builder ---------------------------
 
-def build_metrics(swaps_path: Path, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame:
+def _format_window_tag(start: pd.Timestamp, end: pd.Timestamp) -> str:
+    def _normalize(ts: pd.Timestamp) -> pd.Timestamp:
+        if ts.tzinfo is None:
+            return ts.tz_localize("UTC")
+        return ts.tz_convert("UTC")
+
+    s = _normalize(start).strftime("%Y%m%dT%H%M")
+    e = _normalize(end).strftime("%Y%m%dT%H%M")
+    return f"{s}-{e}"
+
+
+def _extract_peak_from_transactions(
+    path: Path,
+    start_utc: pd.Timestamp,
+    end_utc: pd.Timestamp,
+    *,
+    debug: bool = False,
+) -> Optional[float]:
+    """Return the maximum running peak recorded in the aggregated transaction CSV."""
+
+    try:
+        tx = pd.read_csv(path, low_memory=False)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        if debug:
+            print(f"[warn] failed to read {path}: {exc}")
+        return None
+
+    if tx.empty:
+        return None
+
+    time_col = pick_col(tx, ["first_seen", "block_time", "time", "ts", "block_time_iso"])
+    if not time_col:
+        if debug:
+            print(f"[warn] transaction export lacks timestamp column: {path}")
+        return None
+
+    ts = pd.to_datetime(tx[time_col], utc=True, errors="coerce")
+    tx = tx.loc[pd.notna(ts)].copy()
+    if tx.empty:
+        return None
+
+    tx["__ts"] = ts
+    tx = tx[(tx["__ts"] >= start_utc) & (tx["__ts"] < end_utc)]
+    if tx.empty:
+        return None
+
+    if "running_peak_ui" in tx.columns:
+        series = pd.to_numeric(tx["running_peak_ui"], errors="coerce").dropna()
+        if not series.empty:
+            return float(series.max())
+
+    candidates = []
+    for col in ["running_balance_ui", "post_balance_ui", "pre_balance_ui"]:
+        if col in tx.columns:
+            candidates.append(pd.to_numeric(tx[col], errors="coerce"))
+
+    if not candidates:
+        return None
+
+    combined = pd.concat(candidates, axis=0).dropna()
+    if combined.empty:
+        return None
+
+    return float(combined.max())
+
+
+def _extract_peak_from_history(
+    path: Path,
+    start_utc: pd.Timestamp,
+    end_utc: pd.Timestamp,
+    *,
+    debug: bool = False,
+) -> Optional[float]:
+    """Return the maximum balance observed in the raw Solscan history CSV."""
+
+    try:
+        hist = pd.read_csv(path, low_memory=False)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        if debug:
+            print(f"[warn] failed to read {path}: {exc}")
+        return None
+
+    if hist.empty:
+        return None
+
+    time_col = pick_col(hist, ["time", "ts", "block_time_iso", "block_time", "datetime"])
+    if not time_col:
+        if debug:
+            print(f"[warn] balance history lacks timestamp column: {path}")
+        return None
+
+    ts = pd.to_datetime(hist[time_col], utc=True, errors="coerce")
+    hist = hist.loc[pd.notna(ts)].copy()
+    if hist.empty:
+        return None
+
+    hist["__ts"] = ts
+    hist = hist[(hist["__ts"] >= start_utc) & (hist["__ts"] < end_utc)]
+    if hist.empty:
+        return None
+
+    cols = []
+    if "pre_ui" in hist.columns:
+        cols.append(pd.to_numeric(hist["pre_ui"], errors="coerce"))
+    if "post_ui" in hist.columns:
+        cols.append(pd.to_numeric(hist["post_ui"], errors="coerce"))
+
+    if not cols:
+        return None
+
+    combined = pd.concat(cols, axis=0).dropna()
+    if combined.empty:
+        return None
+
+    return float(combined.max())
+
+
+def _load_balance_peaks(
+    balance_dir: Optional[Path],
+    addresses: Iterable[str],
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    *,
+    debug: bool = False,
+) -> Tuple[Dict[str, float], List[str]]:
+    """Return mapping of address → peak balance (UI) sourced from Solscan history.
+
+    The helper also returns a list of addresses for which we could not find a
+    usable history file so the caller can surface that gap to the analyst. We do
+    **not** fall back to swap-based peaks anymore – the on-chain history is the
+    single source of truth for peak balances.
+    """
+
+    if balance_dir is None:
+        return {}, sorted({a for a in addresses if a})
+
+    if not balance_dir.exists():
+        if debug:
+            print(f"[warn] balance history directory missing: {balance_dir}")
+        return {}, sorted({a for a in addresses if a})
+
+    window_tag = _format_window_tag(start, end)
+    peaks: Dict[str, float] = {}
+    missing: List[str] = []
+
+    # Normalise timestamps once for filtering.
+    start_utc = start.tz_localize("UTC") if start.tzinfo is None else start.tz_convert("UTC")
+    end_utc = end.tz_localize("UTC") if end.tzinfo is None else end.tz_convert("UTC")
+
+    for addr in sorted({a for a in addresses if a}):
+        history_path = balance_dir / f"{addr}_{window_tag}.csv"
+        tx_path = balance_dir / f"{addr}_{window_tag}_transactions.csv"
+
+        peak_val = None
+        if tx_path.exists():
+            peak_val = _extract_peak_from_transactions(
+                tx_path, start_utc, end_utc, debug=debug
+            )
+
+        if peak_val is None and history_path.exists():
+            peak_val = _extract_peak_from_history(
+                history_path, start_utc, end_utc, debug=debug
+            )
+
+        if peak_val is None:
+            if debug:
+                print(
+                    f"[debug] unable to derive peak for {addr}; missing or incomplete Solscan history"
+                )
+            missing.append(addr)
+            continue
+
+        if peak_val < 0:
+            peak_val = 0.0
+
+        peaks[addr] = max(peaks.get(addr, 0.0), peak_val)
+
+    if debug:
+        print(
+            f"[info] loaded balance peaks for {len(peaks)}/{len({a for a in addresses if a})} addresses"
+        )
+        if missing:
+            print(f"[warn] missing balance history for {len(missing)} addresses")
+
+    return peaks, sorted(set(missing))
+
+
+def build_metrics(
+    swaps_path: Path,
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    *,
+    balance_dir: Optional[Path] = None,
+    debug: bool = False,
+) -> pd.DataFrame:
     if not swaps_path.exists():
         raise SystemExit(f"[error] swaps csv not found: {swaps_path}")
 
@@ -116,6 +310,14 @@ def build_metrics(swaps_path: Path, start: pd.Timestamp, end: pd.Timestamp) -> p
     # normalize needed columns
     window["net_tdccp"] = pd.to_numeric(window["net_tdccp"], errors="coerce").fillna(0.0)
 
+    window["__addr"] = window[addr_col].astype(str).str.strip()
+    window = window[window["__addr"] != ""].copy()
+
+    addresses = window["__addr"].dropna().unique().tolist()
+    balance_peaks, missing_history = _load_balance_peaks(
+        balance_dir, addresses, start, end, debug=debug
+    )
+
     # direct vs intermediary
     ilabel = pick_col(window, ["intermediary_label", "route_label", "routing_label"])
     if ilabel is None:
@@ -129,12 +331,12 @@ def build_metrics(swaps_path: Path, start: pd.Timestamp, end: pd.Timestamp) -> p
 
     # group + compute
     out_rows = []
-    for addr, g in window.sort_values("__ts").groupby(window[addr_col]):
+    for addr, g in window.sort_values("__ts").groupby("__addr"):
         net_ui = float(g["net_tdccp"].sum())
 
-        # running balance & peak (within the selected window)
-        bal = g["net_tdccp"].cumsum()
-        peak = float(bal.max()) if len(bal) else 0.0
+        hist_peak = balance_peaks.get(addr)
+        peak_source = "history" if hist_peak is not None else "missing_history"
+        peak = hist_peak if hist_peak is not None else 0.0
 
         n_total = int(len(g))
         n_direct = int(g["__is_direct"].sum())
@@ -148,12 +350,19 @@ def build_metrics(swaps_path: Path, start: pd.Timestamp, end: pd.Timestamp) -> p
             "from_address": addr,
             "net_ui": net_ui,
             "peak_balance_ui": peak,
+            "peak_balance_source": peak_source,
             "first_seen": first_seen.isoformat(),
             "last_seen":  last_seen.isoformat(),
             "direct_txn_count": n_direct,
             "intermediary_txn_count": n_inter,
             "percent_intermediary": round(pct_inter, 6),
         })
+
+    if missing_history and debug:
+        print(
+            "[warn] peak balances defaulted to 0.0 for addresses lacking Solscan history:",
+            ", ".join(missing_history[:10]) + (" …" if len(missing_history) > 10 else ""),
+        )
 
     metrics = pd.DataFrame(out_rows)
     # Stable ordering: larger peak first, then abs(net), then address
@@ -178,6 +387,14 @@ def main():
         "--metrics", default=str(OUT_DEFAULT),
         help=f"Output metrics CSV path (default: {OUT_DEFAULT})"
     )
+    ap.add_argument(
+        "--balance-history-dir",
+        default=str(BALANCE_HISTORY_DIR),
+        help=(
+            "Directory containing per-address balance history CSVs "
+            "(<address>_<start>-<end>.csv). Defaults to data/addresses."
+        ),
+    )
     ap.add_argument("--start", help="ISO start (YYYY-MM-DD). Defaults to settings START.")
     ap.add_argument("--end",   help="ISO end   (YYYY-MM-DD). Defaults to settings END.")
     ap.add_argument("--debug", action="store_true")
@@ -196,14 +413,16 @@ def main():
 
     swaps_path   = Path(args.swaps)
     metrics_path = Path(args.metrics)
+    balance_dir  = Path(args.balance_history_dir) if args.balance_history_dir else None
     metrics_path.parent.mkdir(parents=True, exist_ok=True)
 
     if args.debug:
         print(f"[info] building metrics from {swaps_path}")
         print(f"[info] window {start} → {end}")
+        print(f"[info] balance history dir: {balance_dir}")
         print(f"[info] writing to {metrics_path}")
 
-    m = build_metrics(swaps_path, start, end)
+    m = build_metrics(swaps_path, start, end, balance_dir=balance_dir, debug=args.debug)
     m.to_csv(metrics_path, index=False)
     print(f"[done] metrics → {metrics_path}  (rows={len(m)})")
 

--- a/scripts/fetch_address_history.py
+++ b/scripts/fetch_address_history.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 import argparse
 import csv
+import math
 import os
 import sys
 import time
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
+import numpy as np
 import pandas as pd
 import requests
 
@@ -16,6 +18,23 @@ import requests
 ROOT = Path(__file__).resolve().parents[1]
 SETTINGS_CSV = ROOT / "settings.csv"
 OUT_ROOT = ROOT / "data" / "addresses"
+
+# Column layout for the aggregated transaction export. Keeping it explicit helps
+# downstream tooling (and analysts) understand exactly which fields are
+# available for running-balance reconstruction.
+AGGREGATED_COLUMNS = [
+    "trans_id",
+    "first_seen",
+    "block_time",
+    "net_amount_ui",
+    "abs_amount_ui",
+    "direction",
+    "token_accounts",
+    "pre_balance_ui",
+    "post_balance_ui",
+    "running_balance_ui",
+    "running_peak_ui",
+]
 
 SOLSCAN_BASE = "https://pro-api.solscan.io/v2.0"
 
@@ -62,11 +81,42 @@ def defaults_from_settings() -> tuple[Optional[str], Optional[str]]:
     # Only these two are read from settings.csv
     return read_settings_value("START"), read_settings_value("END")
 
+def _load_env_file(path: Path) -> Dict[str, str]:
+    """Minimal .env parser so the CLI can fall back to repo-local credentials."""
+
+    if not path.exists():
+        return {}
+
+    values: Dict[str, str] = {}
+    with path.open("r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            key = key.strip()
+            val = val.strip()
+            if not key:
+                continue
+            values[key] = val
+    return values
+
+
 def require_api_key() -> str:
     key = os.environ.get("SOLSCAN_API_KEY", "").strip()
     if not key:
-        sys.exit("[error] SOLSCAN_API_KEY not found in environment (.env). "
-                 "Export it or add to your shell env before running.")
+        env_path = ROOT / ".env"
+        env_vars = _load_env_file(env_path)
+        key = env_vars.get("SOLSCAN_API_KEY", "").strip()
+        if key:
+            # Populate os.environ so any downstream helpers can reuse it.
+            os.environ.setdefault("SOLSCAN_API_KEY", key)
+    if not key:
+        sys.exit(
+            "[error] SOLSCAN_API_KEY not found. Export it or add it to .env at the repo root."
+        )
     return key
 
 def http_get_json(url: str, headers: Dict[str, str], params: Dict[str, Any], retries: int = 3, backoff: float = 0.7) -> Dict[str, Any]:
@@ -202,6 +252,126 @@ def fetch_balance_changes(
 
     return df
 
+
+def _aggregate_transactions(hist: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate raw balance changes into per-transaction flows.
+
+    The bubble chart (and forensic workflows) need one row per transaction with
+    enough information to rebuild running balances. We therefore keep:
+
+    * the net signed TDCCP delta ("net_amount_ui")
+    * an absolute magnitude helper ("abs_amount_ui")
+    * the direction (inc/dec/flat)
+    * the set of token accounts touched
+    * total balances immediately before and after the transaction, whenever the
+      Solscan payload provides ``pre_balance``/``post_balance``
+    """
+
+    if hist.empty:
+        return pd.DataFrame(columns=AGGREGATED_COLUMNS)
+
+    work = hist.copy()
+    work["trans_id"] = work["trans_id"].astype(str)
+    work["time_iso"] = pd.to_datetime(work.get("time"), utc=True, errors="coerce")
+    work = work.dropna(subset=["trans_id", "time_iso"])
+    if work.empty:
+        return pd.DataFrame(columns=AGGREGATED_COLUMNS)
+
+    work["direction"] = work.get("change_type", "").astype(str).str.lower()
+    work["amount_ui"] = pd.to_numeric(work.get("amount_ui"), errors="coerce").fillna(0.0)
+    work["pre_ui"] = pd.to_numeric(work.get("pre_ui"), errors="coerce")
+    work["post_ui"] = pd.to_numeric(work.get("post_ui"), errors="coerce")
+    work["signed_amount_ui"] = np.where(
+        work["direction"] == "inc",
+        work["amount_ui"],
+        -work["amount_ui"],
+    )
+    work["token_account"] = work.get("token_account", "").astype(str)
+
+    grouped = work.groupby("trans_id", sort=False)
+    records: List[Dict[str, Any]] = []
+    for tx, grp in grouped:
+        ts = grp["time_iso"].min()
+        block_time = pd.to_numeric(grp.get("block_time"), errors="coerce").min()
+        net = float(grp["signed_amount_ui"].sum())
+        direction = "inc" if net > 0 else "dec" if net < 0 else "flat"
+        accounts = sorted({acc for acc in grp["token_account"] if acc and acc.lower() != "nan"})
+
+        pre_vals = grp["pre_ui"].dropna()
+        post_vals = grp["post_ui"].dropna()
+        pre_total = float(pre_vals.sum()) if not pre_vals.empty else math.nan
+        post_total = float(post_vals.sum()) if not post_vals.empty else math.nan
+
+        records.append({
+            "trans_id": tx,
+            "first_seen": ts,
+            "block_time": block_time,
+            "net_amount_ui": net,
+            "abs_amount_ui": abs(net),
+            "direction": direction,
+            "token_accounts": ";".join(accounts),
+            "pre_balance_ui": pre_total,
+            "post_balance_ui": post_total,
+        })
+
+    agg = pd.DataFrame.from_records(records)
+    if agg.empty:
+        return pd.DataFrame(columns=AGGREGATED_COLUMNS)
+
+    agg = agg.dropna(subset=["first_seen"]).sort_values(["first_seen", "trans_id"])
+    agg["first_seen"] = pd.to_datetime(agg["first_seen"], utc=True)
+
+    running_balances: List[float] = []
+    peak_balances: List[float] = []
+    current = math.nan
+    peak = math.nan
+
+    for _, row in agg.iterrows():
+        pre = row.get("pre_balance_ui")
+        post = row.get("post_balance_ui")
+        delta = float(row.get("net_amount_ui", 0.0))
+
+        # `before` represents the balance immediately preceding the change. If
+        # Solscan supplies a `pre_balance_ui`, trust it; otherwise carry forward
+        # the last known balance (initialising at 0 when nothing is known yet).
+        if not math.isnan(pre):
+            before = float(pre)
+        else:
+            if math.isnan(current):
+                current = 0.0
+            before = float(current)
+
+        # Apply the net change to derive the post-transaction balance. When the
+        # payload includes an explicit `post_balance_ui`, prefer that since it
+        # reflects the authoritative account state after the transaction.
+        after = before + delta
+        if not math.isnan(post):
+            after = float(post)
+
+        current = after
+        running_balances.append(current)
+
+        candidates = [val for val in (before, after) if not math.isnan(val)]
+        if not candidates:
+            candidates = [0.0]
+        max_candidate = max(candidates)
+        if math.isnan(peak):
+            peak = max_candidate
+        else:
+            peak = max(peak, max_candidate)
+        peak_balances.append(peak)
+
+    agg["running_balance_ui"] = running_balances
+    agg["running_peak_ui"] = peak_balances
+
+    # ensure column order
+    for col in AGGREGATED_COLUMNS:
+        if col not in agg.columns:
+            agg[col] = math.nan
+    agg = agg[AGGREGATED_COLUMNS]
+
+    return agg
+
 # ---------------- main ----------------
 def main():
     ap = argparse.ArgumentParser(
@@ -256,11 +426,15 @@ def main():
             "amount_ui","pre_ui","post_ui","owner"
         ]
         pd.DataFrame(columns=empty_cols).to_csv(hist_csv, index=False)
+        tx_csv = OUT_ROOT / f"{owner}_{window_tag}_transactions.csv"
+        pd.DataFrame(columns=AGGREGATED_COLUMNS).to_csv(tx_csv, index=False)
         if args.verbose:
             print(f"[info] no token accounts for mint on this owner → {owner}")
             print(f"[done] balance history → {hist_csv}  (rows=0)")
+            print(f"[done] transactions     → {tx_csv} (rows=0)")
         else:
             print(f"[done] balance history → {hist_csv}  (rows=0)")
+            print(f"[done] transactions     → {tx_csv} (rows=0)")
         return
 
     # 2) balance changes across all token accounts for this mint
@@ -282,6 +456,11 @@ def main():
 
     hist.to_csv(hist_csv, index=False)
     print(f"[done] balance history → {hist_csv}  (rows={len(hist)})")
+
+    tx_csv = OUT_ROOT / f"{owner}_{window_tag}_transactions.csv"
+    tx_df = _aggregate_transactions(hist)
+    tx_df.to_csv(tx_csv, index=False)
+    print(f"[done] transactions     → {tx_csv} (rows={len(tx_df)})")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- strip and normalize swap address keys before resolving balance history
- group metrics by the normalized address so Solscan-derived peaks are picked up instead of falling back to missing_history

## Testing
- python -m compileall scripts/build_bubble_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e357096a8883339eceb6f4368036ce